### PR TITLE
Rediseñar la homepage: acción primero, sin foto de stock ni scores

### DIFF
--- a/src/components/PatientDashboard.tsx
+++ b/src/components/PatientDashboard.tsx
@@ -2,6 +2,7 @@ import {
   BoltIcon,
   CalendarDaysIcon,
   ChatBubbleLeftRightIcon,
+  CheckCircleIcon,
   ClipboardDocumentListIcon,
   HeartIcon,
 } from '@heroicons/react/24/outline';
@@ -14,6 +15,8 @@ import getLocaleDate from '../helpers/get-locale-date';
 import renderValue from '../helpers/get-render-value';
 import { CHECKIN_QUESTIONNAIRE } from '../pages/check-in/definitions';
 import { getPractitionerName } from '../pages/get-care/Appointments';
+
+const WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;
 
 interface DashboardCardProps {
   icon: JSX.Element;
@@ -40,12 +43,53 @@ function DashboardCard({ icon, title, href, linkLabel, children }: DashboardCard
   );
 }
 
+interface GoalRowProps {
+  title: string;
+  tip: string;
+  value: string | JSX.Element | null;
+  valueDate?: string;
+  objective: string;
+  outOfTarget?: boolean;
+  href: string;
+  linkLabel: string;
+}
+
+function GoalRow({ title, tip, value, valueDate, objective, outOfTarget, href, linkLabel }: GoalRowProps): JSX.Element {
+  const borderColor = value === null ? 'border-gray-300' : outOfTarget ? 'border-amber-400' : 'border-emerald-400';
+  return (
+    <div
+      className={`flex flex-col justify-between rounded-md border-l-4 ${borderColor} bg-white p-5 shadow sm:flex-row sm:items-center`}
+    >
+      <div className="sm:pr-6">
+        <h3 className="text-lg font-medium text-gray-900">{title}</h3>
+        <p className="mt-1 text-base text-gray-600">{tip}</p>
+      </div>
+      <div className="mt-3 flex-shrink-0 text-left sm:mt-0 sm:text-right">
+        {value !== null ? (
+          <div className="text-base text-gray-900">
+            <span className="font-semibold">Tu valor: </span>
+            <span className="font-semibold">{value}</span>
+            {valueDate && <span className="text-sm text-gray-500"> ({getLocaleDate(valueDate)})</span>}
+            <span className="text-gray-600"> · Objetivo: {objective}</span>
+          </div>
+        ) : (
+          <p className="text-base text-gray-500">Sin registros todavía · Objetivo: {objective}</p>
+        )}
+        <Link to={href} className="text-base font-medium text-blue-600 hover:text-blue-800">
+          {linkLabel} →
+        </Link>
+      </div>
+    </div>
+  );
+}
+
 export default function PatientDashboard(): JSX.Element {
   const medplum = useMedplum();
   const patient = medplum.getProfile() as Patient;
 
   const [bloodPressure, setBloodPressure] = useState<Observation | null>(null);
   const [activity, setActivity] = useState<Observation | null>(null);
+  const [sleep, setSleep] = useState<Observation | null>(null);
   const [nextAppointment, setNextAppointment] = useState<Appointment | null>(null);
   const [pendingStudies, setPendingStudies] = useState<number | null>(null);
   const [lastCheckIn, setLastCheckIn] = useState<string | null>(null);
@@ -63,6 +107,11 @@ export default function PatientDashboard(): JSX.Element {
       .search('Observation', `code=101691-4&patient=${patientRef}&_sort=-date&_count=1`)
       .then((bundle) => setActivity((bundle.entry?.[0]?.resource as Observation) || null))
       .catch(() => setActivity(null));
+
+    medplum
+      .search('Observation', `code=93832-4&patient=${patientRef}&_sort=-date&_count=1`)
+      .then((bundle) => setSleep((bundle.entry?.[0]?.resource as Observation) || null))
+      .catch(() => setSleep(null));
 
     medplum
       .search('Appointment', `patient=${patientRef}&date=ge${today}&_sort=date&_count=20`)
@@ -96,28 +145,58 @@ export default function PatientDashboard(): JSX.Element {
       .catch(() => setLastCheckIn(null));
   }, [medplum, patient]);
 
+  const checkInDoneThisWeek = !!lastCheckIn && Date.now() - new Date(lastCheckIn).getTime() < WEEK_IN_MS;
+
+  const systolic = bloodPressure?.component?.[1]?.valueQuantity?.value;
+  const diastolic = bloodPressure?.component?.[0]?.valueQuantity?.value;
+  const bloodPressureOut = (systolic !== undefined && systolic >= 140) || (diastolic !== undefined && diastolic >= 90);
+
+  const activityMinutes = activity?.valueQuantity?.value;
+  const sleepHours = sleep?.valueQuantity?.value;
+
   return (
-    <div className="mt-10">
-      <h2 className="mb-6 text-2xl font-bold text-gray-900">Mi Panel</h2>
-      <div className="mb-6 flex flex-col items-start justify-between space-y-4 rounded-md bg-blue-600 p-6 text-white shadow sm:flex-row sm:items-center sm:space-y-0">
-        <div className="flex items-center space-x-4">
-          <ChatBubbleLeftRightIcon className="h-10 w-10 flex-shrink-0" />
-          <div>
-            <h3 className="text-xl font-bold">Check-in semanal</h3>
-            <p className="text-base text-blue-100">
-              {lastCheckIn
-                ? `Último check-in: ${getLocaleDate(lastCheckIn)}. Contanos cómo seguiste.`
-                : 'Contanos cómo te sentiste esta semana. Te toma menos de 2 minutos.'}
-            </p>
+    <div className="mt-8">
+      {checkInDoneThisWeek ? (
+        <div className="flex flex-col items-start justify-between space-y-4 rounded-md border border-emerald-300 bg-emerald-50 p-6 shadow-sm sm:flex-row sm:items-center sm:space-y-0">
+          <div className="flex items-center space-x-4">
+            <CheckCircleIcon className="h-10 w-10 flex-shrink-0 text-emerald-600" />
+            <div>
+              <h2 className="text-xl font-bold text-gray-900">
+                Check-in enviado el {getLocaleDate(lastCheckIn as string)}
+              </h2>
+              <p className="text-base text-gray-600">
+                Tu equipo ya puede verlo. Si algo cambió, podés enviar otro cuando quieras.
+              </p>
+            </div>
           </div>
+          <Link
+            to="/check-in/history"
+            className="inline-flex flex-shrink-0 items-center rounded-md border border-emerald-600 bg-white px-5 py-3 text-base font-medium text-emerald-700 shadow-sm hover:bg-emerald-100"
+          >
+            Ver mis check-ins
+          </Link>
         </div>
-        <Link
-          to="/check-in"
-          className="inline-flex flex-shrink-0 items-center rounded-md bg-white px-5 py-3 text-base font-medium text-blue-700 shadow-sm hover:bg-blue-50"
-        >
-          Hacer mi check-in
-        </Link>
-      </div>
+      ) : (
+        <div className="flex flex-col items-start justify-between space-y-4 rounded-md bg-blue-600 p-6 text-white shadow sm:flex-row sm:items-center sm:space-y-0">
+          <div className="flex items-center space-x-4">
+            <ChatBubbleLeftRightIcon className="h-10 w-10 flex-shrink-0" />
+            <div>
+              <h2 className="text-xl font-bold">¿Cómo te sentiste esta semana?</h2>
+              <p className="text-base text-blue-100">
+                Tu check-in semanal ayuda a tu equipo a detectar cambios a tiempo. Te toma menos de 2 minutos.
+              </p>
+            </div>
+          </div>
+          <Link
+            to="/check-in"
+            className="inline-flex flex-shrink-0 items-center rounded-md bg-white px-5 py-3 text-base font-medium text-blue-700 shadow-sm hover:bg-blue-50"
+          >
+            Hacer mi check-in
+          </Link>
+        </div>
+      )}
+
+      <h2 className="mt-10 mb-6 text-2xl font-bold text-gray-900">Tu semana</h2>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <DashboardCard
           icon={<HeartIcon className="h-6 w-6" />}
@@ -192,7 +271,45 @@ export default function PatientDashboard(): JSX.Element {
           )}
         </DashboardCard>
       </div>
-      <div className="mt-6 rounded-md border border-amber-300 bg-amber-50 p-4">
+
+      <h2 className="mt-10 mb-2 text-2xl font-bold text-gray-900">Lo que cuida tu corazón</h2>
+      <p className="mb-6 text-base text-gray-500">
+        Estos objetivos son una guía general saludable. Tus metas personales las define tu equipo médico.
+      </p>
+      <div className="space-y-4">
+        <GoalRow
+          title="Presión arterial"
+          tip="Movete todos los días, bajá la sal y, si te la indicaron, tomá tu medicación a horario."
+          value={bloodPressure ? renderValue(bloodPressure) : null}
+          valueDate={bloodPressure?.effectiveDateTime}
+          objective="menos de 140 / 90"
+          outOfTarget={bloodPressureOut}
+          href="/health-record/vitals/blood-pressure"
+          linkLabel="Cargar presión de hoy"
+        />
+        <GoalRow
+          title="Actividad física"
+          tip="Caminar también cuenta. Empezá de a poco y sumá minutos cada semana, según cómo te sientas."
+          value={activityMinutes !== undefined ? `${activityMinutes} minutos` : null}
+          valueDate={activity?.effectiveDateTime}
+          objective="30 minutos o más por día"
+          outOfTarget={activityMinutes !== undefined && activityMinutes < 30}
+          href="/health-record/vitals/activity-duration"
+          linkLabel="Registrar actividad"
+        />
+        <GoalRow
+          title="Sueño"
+          tip="Dormir bien ayuda a tu corazón a recuperarse. Tratá de mantener horarios regulares."
+          value={sleepHours !== undefined ? `${sleepHours} horas` : null}
+          valueDate={sleep?.effectiveDateTime}
+          objective="entre 7 y 8 horas"
+          outOfTarget={sleepHours !== undefined && sleepHours < 7}
+          href="/health-record/vitals/sleep-duration"
+          linkLabel="Registrar sueño"
+        />
+      </div>
+
+      <div className="mt-10 rounded-md border border-amber-300 bg-amber-50 p-4">
         <p className="text-lg text-gray-900">
           <span className="font-medium">¿Suspendiste o estás por suspender tu medicación?</span> Contanos por qué: es
           muy importante para tu equipo de Cardio-Oncología.{' '}
@@ -200,6 +317,16 @@ export default function PatientDashboard(): JSX.Element {
             Informar sobre mi medicación
           </Link>
         </p>
+      </div>
+
+      <div className="mt-10 flex flex-col items-center justify-center space-y-4 rounded-md bg-blue-900 p-6 text-center sm:flex-row sm:space-y-0 sm:space-x-6">
+        <p className="text-lg font-medium text-white">¿Tenés una duda? Tu equipo de salud está para ayudarte.</p>
+        <Link
+          to="/messages"
+          className="inline-flex flex-shrink-0 items-center rounded-md bg-white px-6 py-3 text-base font-medium text-blue-900 shadow-sm hover:bg-blue-50"
+        >
+          Escribir a mi equipo
+        </Link>
       </div>
     </div>
   );

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,48 +1,9 @@
-import { useMedplumProfile } from '@medplum/react';
-import { Header } from '../components/Header';
-import { Footer } from '../components/Footer';
-import { GiftIcon } from '@heroicons/react/24/outline';
-import Button from '../components/Button';
-import Carousel from '../components/Carousel';
-import PatientDashboard from '../components/PatientDashboard';
 import { formatHumanName } from '@medplum/core';
-import TaskIcon from '../img/homePage/task-icon.svg?react';
 import { Patient, Practitioner } from '@medplum/fhirtypes';
-
-const carouselItems = [
-  {
-    img: <TaskIcon />,
-    title: 'Prevención HTA ENT',
-    description:
-      'Las Enfermedades Cardiovasculares, Diabetes Tipo II, algunos tipos de cáncer y EPOC. Se pueden prevenir controlando sus factores de riesgo',
-    url: '/get-care',
-    label: 'Factores de Riesgo',
-  },
-  {
-    img: <TaskIcon />,
-    title: 'Mediciones',
-    description:
-      'Registrá tu presión arterial, peso, frecuencia cardíaca, sueño y actividad física para que tu equipo de salud pueda seguir tu evolución',
-    url: '/health-record/vitals',
-    label: 'Ingresar mediciones',
-  },
-  {
-    img: <TaskIcon />,
-    title: 'Tu Medicación',
-    description:
-      '¿Suspendiste o estás por suspender alguna medicación? Contanos por qué: es muy importante para tu equipo de Cardio-Oncología',
-    url: '/health-record/medications',
-    label: 'Informar sobre mi medicación',
-  },
-  {
-    img: <TaskIcon />,
-    title: 'Verificar Email',
-    description:
-      'Queremos ofrecer un servicio simple y muy efectivo. Es por eso que nos preocupa comunicarnos satisfactoriamente con nuestros usuarios',
-    url: '/account',
-    label: 'Enviar mail de verificación',
-  },
-];
+import { useMedplumProfile } from '@medplum/react';
+import { Footer } from '../components/Footer';
+import { Header } from '../components/Header';
+import PatientDashboard from '../components/PatientDashboard';
 
 export function HomePage(): JSX.Element {
   const profile = useMedplumProfile() as Patient | Practitioner;
@@ -59,40 +20,14 @@ export function HomePage(): JSX.Element {
           </a>
         </span>
       </div>
-      <div className="bg-hero-background bg-cover bg-left-top">
-        <section className="mx-auto max-w-7xl px-6 shadow-2xl sm:px-4 md:shadow-none lg:px-8">
-          <div className="py-20">
-            <div className="flex flex-col items-start md:w-128 lg:w-156">
-              <p className="text-1xl max-w-xs sm:text-2xl md:max-w-none md:text-3xl lg:text-4xl">
-                Hola <span className="text-blue-600">{profileName}</span>
-              </p>
-              <Button
-                url="/health-record/vitals/blood-pressure"
-                label="Ingresar nuevos datos de Salud"
-                marginsUtils="m-0 mt-8"
-                paddingUtils="px-10 py-4"
-                fontUtils="medium"
-              />
-            </div>
-          </div>
-        </section>
-      </div>
-      <div className="flex w-full justify-center bg-blue-900 py-4 px-2 sm:px-4 lg:px-8">
-        <div className="flex flex-col items-center space-y-4 font-medium text-white md:flex-row md:space-y-0 md:space-x-6">
-          <GiftIcon className="h-10 w-10 stroke-1 text-white" />
-          <p>¿Cómo te va?</p>
-          <Button
-            label="Enviar Mensaje"
-            url="/messages"
-            marginsUtils="m-0"
-            paddingUtils="px-10 py-4"
-            fontUtils="medium"
-          />
-        </div>
-      </div>
       <div className="w-full bg-gray-50">
-        <section className="mx-auto max-w-7xl px-2 pb-10 sm:px-4 md:pt-6 md:pb-20 lg:px-8">
-          <Carousel items={carouselItems} />
+        <section className="mx-auto max-w-7xl px-4 pt-10 pb-12 sm:px-6 md:pb-20 lg:px-8">
+          <h1 className="text-3xl font-bold text-gray-900 sm:text-4xl">
+            Hola <span className="text-blue-600">{profileName}</span>
+          </h1>
+          <p className="mt-2 text-lg text-gray-600">
+            Tu espacio para seguir tu salud, junto a tu equipo de Cardio-Oncología.
+          </p>
           <PatientDashboard />
         </section>
       </div>


### PR DESCRIPTION
Reestructura la portada del paciente con arquitectura orientada a la acción, adaptada a cardio-oncología:

- Saludo directo y subtítulo del programa, sin foto hero ni carrusel: el contenido útil queda arriba del fold en mobile.
- Check-in como acción primaria sensible al estado: si no se hizo esta semana, CTA destacado; si ya se envió, confirmación con fecha y acceso al historial.
- Sección "Tu semana": las tarjetas de mediciones, próximo turno, pedidos de estudios y actividad física.
- Sección "Lo que cuida tu corazón": factores modificables con valor propio y objetivo general (presión < 140/90, actividad >= 30 min, sueño 7-8 h), resaltados cuando están fuera de objetivo, con la aclaración de que las metas personales las define el equipo médico. Deliberadamente sin scores ni porcentajes de riesgo en la portada.
- Aviso de suspensión de medicación y banda "Escribir a mi equipo" siempre visibles al pie.

Se elimina el carrusel y las imágenes del hero de la home (la landing pública no cambia); el bundle principal baja ~65 KB.


Claude-Session: https://claude.ai/code/session_01BP8r1aWB4f6ig4dnGLPtLX